### PR TITLE
fix(deps): raise floor pins to proven HiveMind stack

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,18 +13,17 @@ dynamic = ["version"]
 dependencies = [
     # bus-client 2.x stack. ovos-audio>=1.2.3 and ovos-dinkum-listener>=0.7.2
     # lifted their ovos-bus-client cap to <3.0.0 (>=1.3.x), so the satellite
-    # now resolves on ovos-bus-client 2.x alongside hivemind-bus-client 0.9.2a1
-    # (which requires ovos-bus-client>=2.0.0a3). Prerelease floors per repo
-    # policy: depend on a prerelease by pinning it as the minimum version so pip
-    # resolves it without --pre.
-    "hivemind-bus-client>=0.9.2a1,<1.0.0",
-    "ovos-bus-client>=2.0.0a3,<3.0.0",
+    # resolves on ovos-bus-client 2.x alongside hivemind-bus-client 1.0.16a1.
+    # Prerelease floors per repo policy: depend on a prerelease by pinning it
+    # as the minimum version so pip resolves it without --pre.
+    "hivemind-bus-client>=1.0.16a1",
+    "ovos-bus-client>=2.9.1a1,<3.0.0",
     "ovos-audio>=1.2.3a1,<2.0.0",
     "ovos-dinkum-listener>=0.7.2a1,<1.0.0",
     # ovos-plugin-manager lifted its ovos-bus-client cap to <3.0.0 in 2.4.1a1;
     # stable 2.2.0 still caps <2.0.0, so the floor must be this prerelease for
     # the 2.x stack to resolve (pinned as the minimum; pip needs no --pre).
-    "ovos-plugin-manager>=2.4.1a1,<3.0.0",
+    "ovos-plugin-manager>=2.11.6a1,<3.0.0",
     "ovos-vad-plugin-silero",
     "ovos-stt-plugin-server",
     "ovos-tts-plugin-server",
@@ -47,10 +46,10 @@ test = ["pytest"]
 e2e = [
     "pytest",
     "pytest-timeout",
-    "hivescope>=0.5.2a1",
-    "hivemind-core>=4.6.2a1",
-    "hivemind-ovos-agent-plugin>=0.3.0a1",
-    "hivemind-plugin-manager>=0.6.0a1",
+    "hivescope>=0.8.0a1",
+    "hivemind-core>=4.13.18a1",
+    "hivemind-ovos-agent-plugin>=0.3.10a1",
+    "hivemind-plugin-manager>=0.9.0a7",
 ]
 
 [project.urls]

--- a/tests/e2e/test_bridge1_conformance.py
+++ b/tests/e2e/test_bridge1_conformance.py
@@ -35,6 +35,7 @@ from hivescope.assertions import (
     assert_source_stamped,
     assert_destination_routed,
     assert_session_inbound_preserved,
+    assert_session_id_natted,
     assert_session_outbound_preserved,
     assert_fifo_order,
     assert_session_propagated_unchanged,
@@ -200,10 +201,12 @@ def test_destination_routed():
 # ─────────────────────────────────────────────────────────────────────────────
 
 def test_session_inbound_preserved():
-    """Satellite's session fields are preserved into bus context.session.
+    """Satellite's session fields are preserved into bus context.session,
+    and its declared session_id is NATted to the connection's per-message
+    Layer-1 id (a non-admin's declared id is never used verbatim on the bus).
 
-    Spec: BRIDGE-1 §4.1 (inbound)
-    Helper: assert_session_inbound_preserved
+    Spec: BRIDGE-1 §4.1 (inbound) / §4 (per-connection session NAT)
+    Helpers: assert_session_inbound_preserved, assert_session_id_natted
     """
     b = _topology_with_utterance()
     b.start_all()
@@ -222,8 +225,9 @@ def test_session_inbound_preserved():
 
         assert_session_inbound_preserved(
             m, s,
-            expected_session={"session_id": sid, "lang": sess.serialize().get("lang")},
+            expected_session={"lang": sess.serialize().get("lang")},
         )
+        assert_session_id_natted(m, s, sid)
     finally:
         b.stop_all()
 


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet 5 (claude-sonnet-5) via Claude Code — NOT human-reviewed. Verify before acting.

Raises dependency floor pins to the set proven working together on the live production HiveMind hub, and drops the stale `hivemind-bus-client <1.0.0` upper cap, which currently excludes the entire 1.0.x line from being installable.

Pins changed in `dependencies`:
- `hivemind-bus-client>=0.9.2a1,<1.0.0` → `hivemind-bus-client>=1.0.16a1` (cap dropped)
- `ovos-bus-client>=2.0.0a3,<3.0.0` → `ovos-bus-client>=2.9.1a1,<3.0.0`
- `ovos-plugin-manager>=2.4.1a1,<3.0.0` → `ovos-plugin-manager>=2.11.6a1,<3.0.0`

Pins changed in the `e2e` extra:
- `hivemind-core>=4.6.2a1` → `hivemind-core>=4.13.18a1`
- `hivemind-ovos-agent-plugin>=0.3.0a1` → `hivemind-ovos-agent-plugin>=0.3.10a1`
- `hivemind-plugin-manager>=0.6.0a1` → `hivemind-plugin-manager>=0.9.0a7`
- `hivescope>=0.5.2a1` → `hivescope>=0.8.0a1`

`ovos-audio` and `ovos-dinkum-listener` are untouched since they are not in the proven set.

The vendored `tests/e2e/test_bridge1_conformance.py` is synced to the shipped session model: hivemind-core >=4.13.18a1 NATs a non-admin's declared `session_id` to `conn_nonce:declared` before it reaches the bus, and hivescope's `assert_session_inbound_preserved` now checks session CONTENTS only (it raises if passed `session_id`). The inbound test now asserts contents via `assert_session_inbound_preserved` and the NAT itself via the new `assert_session_id_natted(master, satellite, declared_id)`, which ships in hivescope 0.8.0a1 (hence the floor, one step past the 0.7.2a1 release that only carries the raise-on-`session_id` half of the change).

Resolve proof: `uv pip install --prerelease=allow -e ".[e2e]"` resolved cleanly. Installed versions matched or exceeded every new floor, including `hivescope 0.8.0a1` and `hivemind-core 4.13.18a1`.

e2e conformance (`tests/e2e/test_bridge1_conformance.py`): 8 passed, 1 skipped, 1 xpassed — all green. Before the conformance-test sync, `test_session_inbound_preserved` failed (old test asserted the verbatim inbound `session_id`, which the NAT no longer preserves).

This change aligns the satellite with the currently deployed `hivemind-core` 4.13.18a1 / `hivemind-bus-client` 1.0.16a1 / `hivescope` 0.8.0a1+ stack, so it can actually be installed and its e2e suite passes against the shipped session model.